### PR TITLE
Fixing URLs; Github's URL change to raw.githubuserfiles.com breaks installation of Git Convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Works on OSX, Linux & Windows git-bash.
 Trial it in your current terminal session:
 
 ```
-eval "$(curl -L https://raw.github.com/jakearchibald/git-convenience/master/setup.sh) trial"
+eval "$(curl -L https://raw.githubusercontent.com/jakearchibald/git-convenience/master/setup.sh) trial"
 ```
 
 If it works for you, have it in all your terminals:
 
 ```
-eval "$(curl -L https://raw.github.com/jakearchibald/git-convenience/master/setup.sh)"
+eval "$(curl -L https://raw.githubusercontent.com/jakearchibald/git-convenience/master/setup.sh)"
 ```
 
 ## Shortcuts
@@ -40,7 +40,7 @@ If you've installed the wonderful [git-up](https://github.com/aanand/git-up) (wh
 
 ## Prompt
 
-![Prompt screenshot](https://raw.github.com/jakearchibald/git-convenience/master/screenshot.png)
+![Prompt screenshot](https://raw.githubusercontent.com/jakearchibald/git-convenience/master/screenshot.png)
 
 The prompt shows the current branch & among other helpful things:
 

--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ eval "$(curl -L https://raw.githubusercontent.com/jakearchibald/git-convenience/
 
 ## Shortcuts
 
-* `gwut` - List all Git Convenience commands and prompt meanings.
+* `gwut` - List all Git Convenience commands and prompt symbols
 * `gs` - git status
-* `gaa` - git add --all - Add all changes (including untracto staging</dd>
-* `gc "Message"` - Commit all changes (except untracked) message</dd>
-* `goops` - Add changes to previous commit &amp; edit comessage</dd>
+* `gaa` - Add all changes (including untracted files) to staging
+* `gc "Message"` - Commit all new files & changes with message
+* `goops` - Add changes to previous commit & edit comessage
 * `gp` - Pull (via rebase) then push
 * `gup` - Pull (via rebase)
-* `glog` - Decorated &amp; graphed log
+* `glog` - Decorated & graphed log
+* `glogo` - As glog, including orphan commits
 * `gdiff` - A word-diff of changes
-* `gclean` - Compress &amp; garbage collect data store
+* `gclean` - Compress & garbage collect data store
 
 
 If you've installed the wonderful [git-up](https://github.com/aanand/git-up) (which you should), it'll be used instead of `git pull --rebase`.

--- a/git-shortcuts.sh
+++ b/git-shortcuts.sh
@@ -3,6 +3,7 @@ alias gaa='git add -A'
 alias gdiff='git diff --color-words'
 alias gclean='git gc --prune=now && git remote prune origin'
 alias glog='git log --graph --oneline --all --decorate'
+alias glogo='glog `git reflog | cut -c1-7`'
 
 if type git-up -t > /dev/null 2>&1; then
 	alias gup='git-up'
@@ -13,7 +14,8 @@ else
 fi
 
 function gc {
-	git commit -am "$1"
+	gaa
+	git commit -m "$1"
 	gs
 }
 
@@ -23,19 +25,19 @@ function goops {
 }
 
 function gwut {
-	#!/bin/bash
 	echo "
 - - - - - - - - - - - - - -
 Git Convenience Shortcuts:
 - - - - - - - - - - - - - -
 gwut - List all Git Convenience commands and prompt symbols.
 gs - git status
-gaa - git add --all - Add all changes (including untracto staging)
-gc "Message" - Commit all changes (except untracked) message
+gaa - Add all changes (including untracted files) to staging
+gc \"Message\" - Commit all new files & changes with message
 goops - Add changes to previous commit & edit comessage
 gp - Pull (via rebase) then push
 gup - Pull (via rebase)
 glog - Decorated & graphed log
+glogo - As glog, including orphan commits
 gdiff - A word-diff of changes
 gclean - Compress & garbage collect data store
 

--- a/setup.sh
+++ b/setup.sh
@@ -24,16 +24,16 @@ function setup_git_convenience {
 
 	# If git completion not installed...
 	if ! type -t __gitcomp > /dev/null 2>&1; then
-		git_load_helper https://raw.github.com/git/git/e90020cdb3273af3b0c7915c0aacf16b19bbf994/contrib/completion/git-completion.bash "$HOME/.git-completion.bash" "$bash_startup_file" "$1"
+		git_load_helper https://raw.githubusercontent.com/git/git/e90020cdb3273af3b0c7915c0aacf16b19bbf994/contrib/completion/git-completion.bash "$HOME/.git-completion.bash" "$bash_startup_file" "$1"
 	fi
 
 	# If git prompt not installed...
 	if ! type -t __git_ps1 > /dev/null 2>&1; then
-		git_load_helper https://raw.github.com/git/git/e90020cdb3273af3b0c7915c0aacf16b19bbf994/contrib/completion/git-prompt.sh "$HOME/.git-prompt.sh" "$bash_startup_file" "$1"
+		git_load_helper https://raw.githubusercontent.com/git/git/e90020cdb3273af3b0c7915c0aacf16b19bbf994/contrib/completion/git-prompt.sh "$HOME/.git-prompt.sh" "$bash_startup_file" "$1"
 	fi
 
-	git_load_helper https://raw.github.com/jakearchibald/git-convenience/master/terminal-prefs.sh "$HOME/.terminal-prefs.sh" "$bash_startup_file" "$1"
-	git_load_helper https://raw.github.com/jakearchibald/git-convenience/master/git-shortcuts.sh "$HOME/.git-shortcuts.sh" "$bash_startup_file" "$1"
+	git_load_helper https://raw.githubusercontent.com/jakearchibald/git-convenience/master/terminal-prefs.sh "$HOME/.terminal-prefs.sh" "$bash_startup_file" "$1"
+	git_load_helper https://raw.githubusercontent.com/jakearchibald/git-convenience/master/git-shortcuts.sh "$HOME/.git-shortcuts.sh" "$bash_startup_file" "$1"
 
 	unset setup_git_convenience
 	unset git_load_helper


### PR DESCRIPTION
Hi Jake,

Was installing my fork of this to a machine and noticed a bunch of the install scripts were returning 400 - seems to be due to Github changing URL for user content from raw.github.com to raw.githubusercontent.com.

This should fix it!

B
